### PR TITLE
Restrict to tex files only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# tags
+tags
+TAGS
+*.swp

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,3 +6,8 @@ History
 ------------------
 
 * First release on PyPI.
+
+0.0.2 (2020-08-17)
+------------------
+
+* Restrict to tex extension only.

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 
     Clean up LaTeX files
-    Copyright (C) 2020  Maxim Ivanov
+    Copyright (C) 2020  Maxim Ivanov, Nico Schlömer
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
 tox==3.14.0
-coverage==4.5.4
+coverage==5.2.1
 Sphinx==1.8.5
 twine==1.14.0
 Click==7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 commit = True
 tag = True
 
@@ -18,7 +18,6 @@ universal = 1
 exclude = docs
 
 [aliases]
-# Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/ivanovmg/whitex',
-    version='0.0.1',
+    version='0.0.2',
     zip_safe=False,
 )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,3 +1,9 @@
+"""Module for testing wimtex.commands.clean function.
+
+Original author: Nico Schlömer, https://github.com/nschloe/blacktex
+
+"""
+
 from textwrap import dedent
 import pytest
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -307,6 +307,39 @@ class TestReplaceDoubleDollarInline(TestAbstract):
         )
         self.run_and_compare(input_string, expected_string)
 
+    def test_replace_double_dollars_on_newlines(self):
+        input_string = dedent(
+            """\
+            this
+            $$
+            a + b = c
+            $$
+            and that
+            """
+        )
+        expected_string = dedent(
+            """\
+            this
+            \\[
+            a + b = c
+            \\]
+            and that
+            """
+        )
+        self.run_and_compare(input_string, expected_string)
+
+    def test_unmatching_dollar_signs_raises(self):
+        input_string = dedent(
+            """\
+            example with unmatching double dollar signs
+            equation $$a + b = c
+            never ends
+            """
+        )
+        with pytest.raises(ValueError, match='Unmatching number'):
+            receiver = TexString(input_string)
+            self.command(receiver).execute()
+
 
 class TestReplaceObsoleteTextMods(TestAbstract):
     command = ReplaceObsoleteTextMods

--- a/tests/test_whitex.py
+++ b/tests/test_whitex.py
@@ -63,3 +63,15 @@ def test_command_line_interface(tmpdir):
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0
     assert '--help  Show this message and exit.' in help_result.output
+
+
+def test_non_tex_file_aborts(tmpdir):
+    """Check that click.ClickException is raised for non-tex file."""
+    input_file = tmpdir / 'input.dat'
+    input_file.write('A string')
+    output_file = tmpdir / 'output.tex'
+
+    runner = CliRunner()
+    runner = CliRunner()
+    result = runner.invoke(cli.main, [str(input_file), str(output_file)])
+    assert result.exit_code == 1  # click.Abort raised

--- a/whitex/__init__.py
+++ b/whitex/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Maxim Ivanov"""
 __email__ = 'ivanovmg@gmail.com'
-__version__ = '0.0.1'
+__version__ = '0.0.2'

--- a/whitex/cli.py
+++ b/whitex/cli.py
@@ -6,11 +6,26 @@ from whitex.whitex import clean_buffer
 
 
 @click.command()
-@click.argument("input_file", type=click.File('r'))
-@click.argument("output_file", type=click.File('w'))
-def main(input_file, output_file):
+@click.argument(
+    "input_fname",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+)
+@click.argument(
+    "output_fname",
+    type=click.Path(dir_okay=False),
+)
+def main(input_fname, output_fname):
     """Console script for whitex."""
-    clean_buffer(input_file, output_file)
+    if not input_fname.endswith('.tex'):
+        msg = (
+            'Expected input file with tex extension, '
+            f'but encountered {input_fname}'
+        )
+        raise click.Abort(msg)
+
+    with open(input_fname, 'r') as input_buf:
+        with open(output_fname, 'w') as output_buf:
+            clean_buffer(input_buf, output_buf)
 
 
 if __name__ == "__main__":

--- a/whitex/commands.py
+++ b/whitex/commands.py
@@ -14,7 +14,7 @@ class Command(ABC):
 
     @abstractmethod
     def execute(self):
-        pass
+        """Abstract execute method."""
 
     def find_locations(self, pattern):
         p = re.compile(pattern)
@@ -104,8 +104,12 @@ class ReplaceDoubleDollarInline(Command):
     def locations(self):
         locations = self.find_locations(r"\$\$")
         if len(locations) % 2 != 0:
-            excerpt = self.receiver.string[locations[0]:20]
-            msg = f"Unmatching number of double dollar signs\n{excerpt}"
+            idx = locations[0]
+            excerpt = self.receiver.string[idx:idx+50]
+            msg = (
+                "Unmatching number of double dollar signs\n"
+                f"Context:\n{excerpt}"
+            )
             raise ValueError(msg)
         return locations
 
@@ -238,8 +242,6 @@ class ReplaceOver(Command):
                 range_, frac_pair = range_and_frac_pair
                 ranges.append(range_)
                 frac_values.append(frac_pair)
-            else:
-                continue
 
         replacements = [
             f"\\frac{{{num}}}{{{den}}}"


### PR DESCRIPTION
- Check for tex file extension and raise error if not tex file.
- Mention original blacktex author, add to copyright.